### PR TITLE
Mutes the menu

### DIFF
--- a/source/src/emulation/audio.cpp
+++ b/source/src/emulation/audio.cpp
@@ -69,6 +69,20 @@ void Audio::volumeUpDown(bool up, bool down) {
   volumeDownLast = down;
 }
 
+void Audio::mute(bool enable) {
+  if (enable) {
+    i2s_set_dac_mode(I2S_DAC_CHANNEL_DISABLE);
+  } else {
+#ifdef SND_DIFF
+    i2s_set_dac_mode(I2S_DAC_CHANNEL_BOTH_EN);
+#elif defined(SND_LEFT_CHANNEL)
+    i2s_set_dac_mode(I2S_DAC_CHANNEL_LEFT_EN);
+#else
+    i2s_set_dac_mode(I2S_DAC_CHANNEL_RIGHT_EN);
+#endif
+  }
+}
+
 void Audio::transmit() {
   // (try to) transmit as much audio data as possible. Since we
   // write data in exact the size of the DMA buffers we can be sure

--- a/source/src/emulation/audio.h
+++ b/source/src/emulation/audio.h
@@ -32,6 +32,7 @@ public:
   void start(machineBase *machineBase);
   void transmit();
   void volumeUpDown(bool up, bool down);
+  void mute(bool enable);
 
 private:
   void namco_render_buffer(void);

--- a/source/src/main.cpp
+++ b/source/src/main.cpp
@@ -196,6 +196,7 @@ void setup() {
     machines[i]->init(&input, frame_buffer, sprite_buffer, memory);
 
   audio.init();
+  audio.mute(true);
   audio.start(currentMachine);
 
   input.init(machinesCount == 1);
@@ -231,6 +232,7 @@ void updateAudioVideo(void) {
   else {
     if (menu.startMachine()) {
       currentMachine = machines[menu.machineIndexSelected()];
+      audio.mute(false);
       audio.start(currentMachine);
       if (currentMachine->videoFlipY())
         video.flipVertical(1);
@@ -248,9 +250,10 @@ void updateAudioVideo(void) {
     // stop current machine
     emulation_stop();
   
+    audio.mute(true);
     menu.show_menu();
     doReset = false;
-  }
+}
 
   bool videoHalfRate = true;
 #ifndef VIDEO_HALF_RATE


### PR DESCRIPTION
This mutes the DAC when in menu so if theres any static it wont be active in the menu. DAC is activated when the game starts. 

Hopefully this code helps, it was AI generated (so apologies for that :) ) I have only been able to test it on my CYD setup so may require some further testing on your devices. Happy to make further changes or if you want to go your own way. Its there if you want it