### PR TITLE
Adding MCP23017 input

### DIFF
--- a/source/platformio.ini
+++ b/source/platformio.ini
@@ -31,6 +31,19 @@ build_flags = ${env.build_flags}
     -D TFT_SPICLK=80000000
     -D CORE_DEBUG_LEVEL=0
 
+[env:release_cheapYellowDisplay_mcp23017]
+board = esp32-2432W328C
+build_type = release
+monitor_raw = yes
+lib_deps =
+    adafruit/Adafruit MCP23017 Arduino Library
+    fastled/FastLED
+build_flags = ${env.build_flags}
+    -D CHEAP_YELLOW_DISPLAY_CONF
+    -D MCP23017_INPUT
+    -D TFT_SPICLK=80000000
+    -D CORE_DEBUG_LEVEL=0
+
 [env:debug_cheapYellowDisplay]
 board = esp32-2432W328C
 build_type = debug

--- a/source/src/config.h
+++ b/source/src/config.h
@@ -53,7 +53,7 @@
   #define TFT_CS          15
   #define TFT_DC          2
   #define TFT_RST         -1
-  #define TFT_BL          27   // don't set if backlight is hard wired
+  #define TFT_BL          27   // don't set if backlight is hard wired, some CYD's maybe pin 21
   #define TFT_BL_LEVEL    HIGH  // backlight on with low or high signal
   //#define TFT_ILI9341 // define for ili9341, otherwise st7789
   //#define TFT_VFLIP   // define for upside down
@@ -63,15 +63,28 @@
   #define TFT_SCLK 	      14
   //#define TFT_MAC  	    0x20  // some CYD need this to rotate properly and have correct colors
 
-  // Pins used for buttons
-  #define BTN_START_PIN	  35
-  //#define BTN_COIN_PIN    21   // if this is not defined, then start will act as coin & start
+  #ifndef MCP23017_INPUT
+    // Pins used for buttons
+    #define BTN_START_PIN	  35
+    //#define BTN_COIN_PIN    21   // if this is not defined, then start will act as coin & start
 
-  #define BTN_LEFT_PIN    21
-  #define BTN_RIGHT_PIN   22
-  #define BTN_DOWN_PIN    16
-  #define BTN_UP_PIN      17
-  #define BTN_FIRE_PIN    4
+    #define BTN_LEFT_PIN    21
+    #define BTN_RIGHT_PIN   22
+    #define BTN_DOWN_PIN    16
+    #define BTN_UP_PIN      17
+    #define BTN_FIRE_PIN    4
+  #else
+    #define MCP23017_SDA    22
+    #define MCP23017_SCL    27
+    #define MCP23017_LEFT_PIN   0
+    #define MCP23017_RIGHT_PIN  1
+    #define MCP23017_UP_PIN     2
+    #define MCP23017_DOWN_PIN   3
+    #define MCP23017_FIRE_PIN   4
+    #define MCP23017_EXTRA_PIN  5
+    #define MCP23017_COIN_PIN   6
+    #define MCP23017_START_PIN  7
+  #endif
 #endif
 
 #ifndef CHEAP_YELLOW_DISPLAY_CONF

--- a/source/src/emulation/input.cpp
+++ b/source/src/emulation/input.cpp
@@ -2,7 +2,7 @@
 
 void Input::init(char SingleMachine) {
   singleMachine = SingleMachine;
-#ifndef NUNCHUCK_INPUT
+#if !defined(NUNCHUCK_INPUT) && !defined(MCP23017_INPUT)
   pinMode(BTN_START_PIN, INPUT_PULLUP);
   #ifdef BTN_COIN_PIN
     pinMode(BTN_COIN_PIN, INPUT_PULLUP);
@@ -12,8 +12,10 @@ void Input::init(char SingleMachine) {
   pinMode(BTN_DOWN_PIN, INPUT_PULLUP);
   pinMode(BTN_UP_PIN, INPUT_PULLUP);
   pinMode(BTN_FIRE_PIN, INPUT_PULLUP);
-#else
+#elif defined(NUNCHUCK_INPUT)
   nunchuck.setup();
+#elif defined(MCP23017_INPUT)
+  mcp.setup();
 #endif
 
   char inputs = buttons_get();
@@ -32,11 +34,18 @@ void Input::enable() {
 #ifdef NUNCHUCK_INPUT
   nunchuck.enable();
 #endif
+#ifdef MCP23017_INPUT
+  mcp.enable();
+#endif
 }
 
 void Input::disable() {
 #ifdef NUNCHUCK_INPUT
   nunchuck.disable();
+  vTaskDelay(100);
+#endif
+#ifdef MCP23017_INPUT
+  mcp.disable();
   vTaskDelay(100);
 #endif
 }
@@ -47,6 +56,8 @@ unsigned char Input::buttons_get(void) {
   unsigned char input_states = 0;
 #ifdef NUNCHUCK_INPUT
   input_states = nunchuck.getInput();  
+#elif defined(MCP23017_INPUT)
+  input_states = mcp.getInput();
 #else
   #ifdef BTN_COIN_PIN
     input_states = (!digitalRead(BTN_COIN_PIN)) ? BUTTON_EXTRA : 0;

--- a/source/src/emulation/input.h
+++ b/source/src/emulation/input.h
@@ -6,6 +6,9 @@
 #ifdef NUNCHUCK_INPUT
   #include "nunchuck.h"
 #endif
+#ifdef MCP23017_INPUT
+  #include "mcp23017.h"
+#endif
 
 // a total of 7 button is needed for most games
 #define BUTTON_LEFT  0x01
@@ -48,6 +51,9 @@ private:
   char firePressedAtStart;
 #ifdef NUNCHUCK_INPUT
   Nunchuck nunchuck;
+#endif
+#ifdef MCP23017_INPUT
+  MCP23017 mcp;
 #endif
 };
 

--- a/source/src/emulation/mcp23017.cpp
+++ b/source/src/emulation/mcp23017.cpp
@@ -1,0 +1,64 @@
+#include "mcp23017.h"
+
+#ifdef MCP23017_INPUT
+#include "input.h"
+
+void MCP23017::setup() {
+  Serial.printf("MCP23017 setup: SDA=%d, SCL=%d\n", MCP23017_SDA, MCP23017_SCL);
+  Wire.begin(MCP23017_SDA, MCP23017_SCL);
+  delay(100);
+  
+  if (!mcp.begin_I2C(0x20, &Wire)) {
+    Serial.println("MCP23017 not detected at 0x20!");
+    // Try scanning or something?
+  } else {
+    Serial.println("MCP23017 detected!");
+  }
+
+  // Setup pins as input with pullup
+  mcp.pinMode(MCP23017_LEFT_PIN, INPUT_PULLUP);
+  mcp.pinMode(MCP23017_RIGHT_PIN, INPUT_PULLUP);
+  mcp.pinMode(MCP23017_UP_PIN, INPUT_PULLUP);
+  mcp.pinMode(MCP23017_DOWN_PIN, INPUT_PULLUP);
+  mcp.pinMode(MCP23017_FIRE_PIN, INPUT_PULLUP);
+  mcp.pinMode(MCP23017_START_PIN, INPUT_PULLUP);
+  mcp.pinMode(MCP23017_COIN_PIN, INPUT_PULLUP);
+  mcp.pinMode(MCP23017_EXTRA_PIN, INPUT_PULLUP);
+
+  timeout = millis() + 200;
+  enable();
+}
+
+void MCP23017::enable() {
+  enabled = true;
+}
+
+void MCP23017::disable() {
+  enabled = false;
+}
+
+unsigned char MCP23017::getInput() {
+  unsigned long now = millis();
+  if(!enabled || now - timeout < 20)
+    return lastValue;
+  else
+    timeout = now;
+
+  // Read all pins from MCP23017
+  // We can read both ports at once if we want to optimize, but let's use individual digitalRead for now as it's cleaner
+  // or use readGPIOAB()
+  uint16_t gpio = mcp.readGPIOAB();
+
+  lastValue = 
+    ((gpio & (1 << MCP23017_LEFT_PIN)) ? 0 : BUTTON_LEFT) |
+    ((gpio & (1 << MCP23017_RIGHT_PIN)) ? 0 : BUTTON_RIGHT) |
+    ((gpio & (1 << MCP23017_UP_PIN)) ? 0 : BUTTON_UP) |
+    ((gpio & (1 << MCP23017_DOWN_PIN)) ? 0 : BUTTON_DOWN) |
+    ((gpio & (1 << MCP23017_FIRE_PIN)) ? 0 : BUTTON_FIRE) |
+    ((gpio & (1 << MCP23017_START_PIN)) ? 0 : BUTTON_START) |
+    ((gpio & (1 << MCP23017_COIN_PIN)) ? 0 : BUTTON_COIN) |
+    ((gpio & (1 << MCP23017_EXTRA_PIN)) ? 0 : BUTTON_EXTRA);
+
+  return lastValue;
+}
+#endif

--- a/source/src/emulation/mcp23017.h
+++ b/source/src/emulation/mcp23017.h
@@ -1,0 +1,26 @@
+#ifndef _MCP23017_H_
+#define _MCP23017_H_
+
+#include <Arduino.h>
+#include "../config.h"
+
+#ifdef MCP23017_INPUT
+#include <Adafruit_MCP23X17.h>
+
+class MCP23017 {
+public:
+  void setup();
+  void enable();
+  void disable();
+  unsigned char getInput();
+ 
+private:
+  Adafruit_MCP23X17 mcp;
+  bool enabled;
+  unsigned long timeout;
+  unsigned char lastValue;
+};
+
+#endif
+
+#endif //_MCP23017_H_


### PR DESCRIPTION
Hi

As mentioned in the other galagino thread, I have some galagino devices that use a MCP23017 I2C expander board. Heres one of them: https://www.hackster.io/dynamight/cyd-galagino-handheld-7c796c the other is a cabinet. 

So when I saw your project I was quite keen as loved the idea of adding more games :) Asked AI to add a new driver and keep it as clean as I could without making large changes to your existing code. AI agreed that your code was extremely well implemented and it could do it without large changes.

So heres the changes, its totally fine if you cant merge without testing. I'll keep it on mine anyway and point others towards it if anyone actually builds one of my devices. It'll be the one on my personal device for sure! 

Thanks