### PR TITLE
Adds LED marquee for Starforce and Moon Cresta

### DIFF
--- a/source/src/emulation/led.cpp
+++ b/source/src/emulation/led.cpp
@@ -7,7 +7,7 @@ void Led::init() {
 }
 
 void Led::update(machineBase *machines[], signed char machineIndexPreselection, signed char machineSelected) {
-  if (machineSelected == MCH_MENU)
+  if (machineSelected < 0)
     machines[machineIndexPreselection]->menuLeds(leds);
   else
     machines[machineSelected]->gameLeds(leds);

--- a/source/src/machines/mooncresta/mooncresta.cpp
+++ b/source/src/machines/mooncresta/mooncresta.cpp
@@ -385,3 +385,23 @@ inline unsigned short mooncresta::rgb_to_swapped565(unsigned char r, unsigned ch
 const unsigned short *mooncresta::logo(void) {
   return mooncresta_logo;
 }
+
+#ifdef LED_PIN
+void mooncresta::gameLeds(CRGB *leds) {
+  static char sub_cnt = 0;
+  if(sub_cnt++ == 32) {
+    sub_cnt = 0;
+    static char led = 0;
+    char il = (led < NUM_LEDS) ? led : ((2 * NUM_LEDS - 2) - led);
+    for(char c = 0; c < NUM_LEDS; c++) {
+      if(c == il) leds[c] = LED_YELLOW;
+      else        leds[c] = LED_BLUE;
+    }
+    led = (led + 1) % (2 * NUM_LEDS - 2);
+  }
+}
+
+void mooncresta::menuLeds(CRGB *leds) {
+  memcpy(leds, menu_leds, NUM_LEDS * sizeof(CRGB));
+}
+#endif

--- a/source/src/machines/mooncresta/mooncresta.h
+++ b/source/src/machines/mooncresta/mooncresta.h
@@ -83,6 +83,11 @@ public:
   void render_row(short row) override;
   const unsigned short *logo(void) override;
 
+#ifdef LED_PIN
+  void menuLeds(CRGB *leds) override;
+  void gameLeds(CRGB *leds) override;
+#endif
+
 protected:
   void blit_tile(short row, char col) override;
   void blit_sprite(short row, unsigned char s) override;
@@ -111,5 +116,9 @@ private:
  
   uint8_t gfx_bank[4] = {0x00,0x00,0x00,0x00};
   uint8_t gfx_scroll;
-};
-#endif
+
+  #ifdef LED_PIN
+   const CRGB menu_leds[7] = { LED_YELLOW, LED_BLUE, LED_GREEN, LED_WHITE, LED_GREEN, LED_BLUE, LED_YELLOW };
+  #endif
+  };
+  #endif

--- a/source/src/machines/starforce/starforce.cpp
+++ b/source/src/machines/starforce/starforce.cpp
@@ -596,3 +596,23 @@ void starforce::render_row(short row) {
 const unsigned short *starforce::logo(void) {
   return starforce_logo;
 }
+
+#ifdef LED_PIN
+void starforce::gameLeds(CRGB *leds) {
+  static char sub_cnt = 0;
+  if(sub_cnt++ == 32) {
+    sub_cnt = 0;
+    static char led = 0;
+    char il = (led < NUM_LEDS) ? led : ((2 * NUM_LEDS - 2) - led);
+    for(char c = 0; c < NUM_LEDS; c++) {
+      if(c == il) leds[c] = LED_WHITE;
+      else        leds[c] = LED_BLUE;
+    }
+    led = (led + 1) % (2 * NUM_LEDS - 2);
+  }
+}
+
+void starforce::menuLeds(CRGB *leds) {
+  memcpy(leds, menu_leds, NUM_LEDS * sizeof(CRGB));
+}
+#endif

--- a/source/src/machines/starforce/starforce.h
+++ b/source/src/machines/starforce/starforce.h
@@ -49,6 +49,11 @@ public:
 	void render_row(short row) override;
 	const unsigned short *logo(void) override;
 
+#ifdef LED_PIN
+	void menuLeds(CRGB *leds) override;
+	void gameLeds(CRGB *leds) override;
+#endif
+
 protected:
 	void blit_tile_bg(short logical_row);
 	void blit_tile_fg(short row, char col);
@@ -70,6 +75,11 @@ private:
 
 	unsigned char coinBackup = 0;
 	unsigned char coinFrameCounter = 0;
-};
 
-#endif
+	#ifdef LED_PIN
+		const CRGB menu_leds[7] = { LED_BLUE, LED_CYAN, LED_BLUE, LED_WHITE, LED_BLUE, LED_CYAN, LED_BLUE };
+	#endif
+
+	};
+
+	#endif


### PR DESCRIPTION
Hi

Thanks for the new games, great work as always! My device uses the LED marquee and I noticed the new games didnt have any LED's so I added some. Theres also a small fix so the LED's change when cycling through the menu as before they were static (and based on whatever one appeared first)

Hopefully its ok to accept this PR.

Thanks